### PR TITLE
로그인화면 count영역 margin-top 추가

### DIFF
--- a/src/assets/style/contents.scss
+++ b/src/assets/style/contents.scss
@@ -34,6 +34,7 @@
       font-weight: 700;
       line-height: 48px;
       color: #f79c22;
+      margin-top: 4px;
     }
   }
   .desc {


### PR DESCRIPTION
로그인화면 count영역 margin-top 추가
- 사용중인 지마켓폰트 숫자에따라 상하 정렬 수평문제 존재하여, 상단 마진값 주어 중앙으로 맞추었음